### PR TITLE
Use set -e to fail if rsync doesn't complete

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -61,7 +61,6 @@
 # FTP... variables are only necessary for FTP deployment (uses LFTP).
 # Set these for each of your destination servers.
 
-
 echo "Starting deployment..."
 
 # Unshallow to get tags
@@ -109,7 +108,10 @@ then
             ssh_port=$SSH_LIVE_PORT
         fi
 
+        # Exit if rsync fails
+        set -e
         rsync -a -v -e "ssh -p $ssh_port" --stats --progress "$HOME/cache/_site/" "$SSH_LIVE":"$DESTINATIONPATH_LIVE"
+        set +e
     else
         lftp -d -c "open -u $FTP_USER_LIVE,$FTP_PASSWORD_LIVE $FTP_HOST_LIVE; set ssl:verify-certificate no; mirror -Rv '$HOME/cache/_site/' '$DESTINATIONPATH_LIVE'"
     fi
@@ -136,12 +138,16 @@ else
                 ssh_port=$SSH_PREVIEWS_PORT
             fi
 
+            # Exit if rsync fails
+            set -e
             rsync -a -v -e "ssh -p $ssh_port" --stats --progress "$HOME/cache/_site/" "$SSH_PREVIEWS":"$DESTINATIONPATH_PREVIEWS/$tag"
+            set +e
         else
             # If your server can't handle a queue of FTP commands,
             # you may need to remove `set ftp:sync-mode false;`
             lftp -d -c "open -u $FTP_USER_PREVIEWS,$FTP_PASSWORD_PREVIEWS $FTP_HOST_PREVIEWS; set ssl:verify-certificate no; set ftp:sync-mode false; mirror -Rv '$HOME/cache/_site/' '$DESTINATIONPATH_PREVIEWS/$tag'"
         fi
+        echo "Preview site deployed."
     else
         if [[ $DEPLOY_METHOD_STAGING == 'SSH' ]]
         then
@@ -151,13 +157,15 @@ else
                 ssh_port=$SSH_STAGING_PORT
             fi
 
+            # Exit if rsync fails
+            set -e
             rsync -a -v -e "ssh -p $ssh_port" --stats --progress "$HOME/cache/_site/" "$SSH_STAGING":"$DESTINATIONPATH_STAGING"
+            set +e
         else
             # If your server can't handle a queue of FTP commands,
             # you may need to remove `set ftp:sync-mode false;`
             lftp -d -c "open -u $FTP_USER_STAGING,$FTP_PASSWORD_STAGING $FTP_HOST_STAGING; set ssl:verify-certificate no; set ftp:sync-mode false; mirror -Rv '$HOME/cache/_site/' '$DESTINATIONPATH_STAGING'"
         fi
+        echo "Staging site deployed."
     fi
-    echo "Staging site deployed."
-
 fi


### PR DESCRIPTION
If rsync can't connect over SSH, it exits with a zero exit code, which denotes success, and CodeShip thinks the deployment completed successfully. I suspect that since rsync is executing the SSH command, when SSH fails the error is with SSH inside an rsync wrapper. rsync does not pass the SSH error code through and return it. rsync just continues on its happy way, and we get a zero exit code (i.e. success) from rsync.

I've tried unsuccessfully to detect the SSH-failure exit code, and to grep an error message from rsync.

Using `set -e` does the trick, though. Not sure how it's detecting an error I couldn't pick up, but I guess that's what it's for.

I've also tried using `set -e` for the entire script, but this led to early deploy failures without logging any debugging info, perhaps because there are no-zero exit codes inherent to the git-related checks we do in the deploy script.