### PR TITLE
Use simpler git log command for Codeship

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -70,7 +70,7 @@ then
 fi
 
 # Get the short hash of the latest commit
-commit=$(git log --pretty=format:"%h" -n 1^ 2>&1)
+commit=$(git rev-parse --short=7 HEAD 2>&1)
 
 # Get the tag on the last commit
 tag=$(git describe --tags --exact-match $commit 2>&1)

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,7 @@ fi
 echo "Branch: $branch"
 
 # Get the short hash of the latest commit
-commit=$(git log --pretty=format:"%h" -n 1^ 2>&1)
+commit=$(git rev-parse --short=7 HEAD 2>&1)
 echo "Commit: $commit"
 
 # Get the tag on the last commit


### PR DESCRIPTION
Our previous method for getting the short hash of the last commit stopped working on Codeship. This uses a simpler-to-read method that works fine.